### PR TITLE
Require Python 3.6 or newer for pack.py

### DIFF
--- a/CMake/PackSDFConfig.cmake
+++ b/CMake/PackSDFConfig.cmake
@@ -1,4 +1,5 @@
-find_package(PythonInterp)
+# pack.py now uses f-strings which were introduced in Python 3.6
+find_package(Python3 3.6 REQUIRED)
 find_file(PACK_PY pack.py
    PATHS ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_LIST_DIR}/../src
    DOC "Path to pack.py")

--- a/CMake/pack.cmake.in
+++ b/CMake/pack.cmake.in
@@ -12,7 +12,7 @@ set(ENV{GIT_DIR} @GIT_DIR@)
 # are interpreted correctly.
 # The trailing whitespace to "-O3 ", is stripped within pack.py.
 execute_process(
-   COMMAND "@PYTHON_EXECUTABLE@" "@PACK_PY@" @PACK_OPTS@
+   COMMAND "@Python3_EXECUTABLE@" "@PACK_PY@" @PACK_OPTS@
       @CMAKE_CURRENT_BINARY_DIR@/@INFO_FILE@ "@FC_INFO@ "
       "@FFLAGS@ " @SOURCE_ALL@
       RESULT_VARIABLE RET)


### PR DESCRIPTION
...since pack.py now uses f-strings.