### PR TITLE
Avoid an IndexError when parsing the name of a Git branch

### DIFF
--- a/src/pack.py
+++ b/src/pack.py
@@ -433,7 +433,7 @@ else:
         bname = bname.decode('ascii').rstrip()
         bnames = bname.split('/', 2)
         bname = bnames[-1]
-        if bnames[1] == 'remotes':
+        if len(bnames) > 1 and bnames[1] == 'remotes':
             remote = bname.split('/')[0]
             sremote = "remote"
 


### PR DESCRIPTION
Sometimes, in a CI environment, the local copy of a git repository doesn't contain any refs
and the output of `git rev-parse --symbolic-full-name ...` can be just a single word instead
of "refs/remotes/....".